### PR TITLE
Cancel Subscription Endpoint

### DIFF
--- a/app/controllers/api/v1/customers/subscriptions_controller.rb
+++ b/app/controllers/api/v1/customers/subscriptions_controller.rb
@@ -23,7 +23,40 @@ class Api::V1::Customers::SubscriptionsController < ApplicationController
       end
       render json: SubscriptionSerializer.new(subscription), status: :created
     else
-      render json: { description: "Error: Invalid parameters"}, status: :not_found
+      render json: { description: "Error: Invalid parameters" }, status: :not_found
+    end
+  end
+
+  def update
+    subscription = Subscription.find_by_id(params[:id])
+    if subscription.present?
+      if params[:change] == 'cancel'
+        cancel_subscription(subscription)
+      # elsif restart_subscription
+        # Some stuff to restart a subscription
+      # elsif add_tea
+        # Some stuff here to add a tea
+      # elsif remove_tea
+        # Some stuff here to remove a tea
+      # elsif change_frequency
+        # Some stuff here to change frequency
+      end
+    else
+      render json: { description: "Error: Invalid parameters" }, status: :not_found
+    end
+  end
+
+  private
+  # def valid_update_param?
+  #   ['cancel', 'restart_subscription', 'add_tea', 'remove_tea', 'change_frequency'].include?(params[:change])
+  # end
+
+  def cancel_subscription(subscription)
+    if subscription.active?
+      subscription.cancelled!
+      render json: SubscriptionSerializer.new(subscription), status: :ok
+    else
+      render json: { description: "Error: Subscription is already cancelled" }, status: :not_found
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do 
     namespace :v1 do
       resources :customer, only: [] do
-        resources :subscriptions, only: [ :index, :create ], controller: 'customers/subscriptions'
+        resources :subscriptions, only: [ :index, :create, :update ], controller: 'customers/subscriptions'
       end
     end
   end


### PR DESCRIPTION
- [ ] **Fixes**: 
> - 

- [x] **Completes**:
> - Adds tests for Cancel Subscription endpoint
> - Adds functionality for Cancel Subscription endpoint
> - Functions correctly when testing via RSpec or Postman

- [ ] **Updates**:
> - 

- [x] **Needs attention**:  
> -  Will need to add sad path tests for passing an incorrect change parameter, incorrect customer ID when updating a subscription

**Other Notes**:
